### PR TITLE
feat(flux): GitHub webhook receiver for push-based reconciliation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,6 +86,16 @@ Apps are grouped under `cluster/apps/` by namespace: `cnpg`, `default`, `kube-sy
 - TLS secret name pattern: `${SECRET_LAB_DOMAIN/./-}-tls`
 - Reference templates: `cluster/apps/default/lidarr/app/ingress.yaml` (internal), `cluster/apps/default/searxng/app/ingress.yaml` (external)
 
+## GitHub Webhook (push-based reconciliation)
+
+Flux reconciles the `flux-system` GitRepository on push via a `Receiver`, avoiding the 1m poll delay (the poll interval stays as a fallback).
+
+- Manifests: `cluster/apps/networking/webhook-receiver/` (Receiver + Service + Ingress + SOPS secret, all in `flux-system` namespace)
+- The `webhook-receiver` Service targets `app: notification-controller` on port `9292`; the public Ingress (`flux-webhook.${SECRET_LAB_DOMAIN}`, external Traefik + Cloudflare tunnel) forwards `/hook` to it.
+- The GitHub webhook URL is `https://flux-webhook.${SECRET_LAB_DOMAIN}` + the receiver path. The path is **only known after reconciliation** — get it with:
+  `kubectl -n flux-system get receiver github-webhook -o jsonpath='{.status.webhookPath}'`
+- Shared HMAC secret lives in `secret.sops.yaml` (key `token`) and must match the webhook "Secret" configured in GitHub (repo → Settings → Webhooks, content type `application/json`, events: `push`).
+
 ## Middlewares
 
 - `networking-internal-ips-only@kubernetescrd` - IP allowlist (10.0.0.0/8, 100.64.0.0/10, lab IPs)

--- a/cluster/apps/networking/kustomization.yaml
+++ b/cluster/apps/networking/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
   - ./globalping-probe/ks.yaml
   - ./smtp-relay/ks.yaml
   - ./traefik/ks.yaml
+  - ./webhook-receiver/ks.yaml

--- a/cluster/apps/networking/webhook-receiver/app/ingress.yaml
+++ b/cluster/apps/networking/webhook-receiver/app/ingress.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: webhook-receiver
+  namespace: flux-system
+  annotations:
+    external-dns.alpha.kubernetes.io/target: "${SECRET_CLOUDFLARE_TUNNEL_DOMAIN}"
+    external-dns.alpha.kubernetes.io/cloudflare-proxied: "true"
+    traefik.ingress.kubernetes.io/router.entrypoints: "websecure"
+    traefik.ingress.kubernetes.io/router.middlewares: "networking-cloudflarewarp@kubernetescrd"
+    traefik.ingress.kubernetes.io/service.serversscheme: "http"
+    external-dns/external: "true"
+spec:
+  ingressClassName: traefik
+  tls:
+    - hosts:
+        - "flux-webhook.${SECRET_LAB_DOMAIN}"
+      secretName: "${SECRET_LAB_DOMAIN/./-}-tls"
+  rules:
+    - host: "flux-webhook.${SECRET_LAB_DOMAIN}"
+      http:
+        paths:
+          - path: /hook
+            pathType: Prefix
+            backend:
+              service:
+                name: webhook-receiver
+                port:
+                  number: 80

--- a/cluster/apps/networking/webhook-receiver/app/kustomization.yaml
+++ b/cluster/apps/networking/webhook-receiver/app/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - secret.sops.yaml
+  - receiver.yaml
+  - service.yaml
+  - ingress.yaml

--- a/cluster/apps/networking/webhook-receiver/app/receiver.yaml
+++ b/cluster/apps/networking/webhook-receiver/app/receiver.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: notification.toolkit.fluxcd.io/v1
+kind: Receiver
+metadata:
+  name: github-webhook
+  namespace: flux-system
+spec:
+  type: github
+  events:
+    - "ping"
+    - "push"
+  secretRef:
+    name: github-webhook
+  resources:
+    - kind: GitRepository
+      name: flux-system

--- a/cluster/apps/networking/webhook-receiver/app/secret.sops.yaml
+++ b/cluster/apps/networking/webhook-receiver/app/secret.sops.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: github-webhook
+    namespace: flux-system
+type: Opaque
+stringData:
+    token: ENC[AES256_GCM,data:cbx14ZiiZd/Gy/zQ+GPZ6lL0J3oR5Wkut14Jclpx4ufIaL6i8tRUYA==,iv:iQC7V2laMILc21WITZ57lRCPiDA+V5vqZLTzer3cRCA=,tag:2o+6V0Fs4ppp0bsnQ1DwyA==,type:str]
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA5NmcyczU0SFJzU1VIZGlz
+            QlhYMFFxK2hxWnlXNjFKSXc2VS94TWtEcVZNCncrdHltcDEzU2NqNHpPc3kxSEFT
+            YTlvM2Q5c0ptSGpPTWF0VHRTRk1RLzQKLS0tIFI0N3V1Z21lZ0JqcENqZnpMMW9D
+            clRiYmpwVEdxYnRNa0FHNFVkSlNpeXcKgpyGcxqHTw2E5+kyYrvk6BGHseo7j/Uu
+            3li2tganBepRZHyYLGR/Tgt+Cixz/yXap0G8ianzVkKDLZHqWHl5AA==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1f897y4l6lrasc0rcgrkz3q4054rk7ewa6gh7g4zruk0vzjp22a9sl6fr55
+    encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-07-19T12:54:58Z"
+    mac: ENC[AES256_GCM,data:dE4YfQq3A2moV5yDAD6pnaaB+cJHut/TPSh6uWKLgSFiiQxW4ka8PzigmfgoabcJsjvZVwocP8tTx7RZwKFpmLqNnfKCL5fqdU7T2KrPsOLAo8BcVuMiMXEE6OxJ1VbimdaYyQj+OwNjbkgtEN2zuMaJgTNhSbXli7HQ83IQNqw=,iv:wxDjgopxRWzacLSXwpRHhBv4bpuqYTIph97ivNN8Sbo=,tag:dVr8+zSYZbJv4qqIKt0fQQ==,type:str]
+    version: 3.13.2

--- a/cluster/apps/networking/webhook-receiver/app/service.yaml
+++ b/cluster/apps/networking/webhook-receiver/app/service.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: webhook-receiver
+  namespace: flux-system
+spec:
+  selector:
+    app: notification-controller
+  ports:
+    - name: http
+      port: 80
+      protocol: TCP
+      targetPort: 9292

--- a/cluster/apps/networking/webhook-receiver/ks.yaml
+++ b/cluster/apps/networking/webhook-receiver/ks.yaml
@@ -1,0 +1,26 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/refs/heads/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: apps-networking-webhook-receiver
+  namespace: flux-system
+spec:
+  interval: 5m
+  path: ./cluster/apps/networking/webhook-receiver/app
+  prune: true
+  wait: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  decryption:
+    provider: sops
+    secretRef:
+      name: sops-age
+  postBuild:
+    substitute: {}
+    substituteFrom:
+      - kind: ConfigMap
+        name: cluster-settings
+      - kind: Secret
+        name: cluster-secrets


### PR DESCRIPTION
Adds a Flux `Receiver` so pushes to `main` trigger immediate reconciliation of the `flux-system` GitRepository instead of waiting for the 1m poll (poll stays as fallback). Mirrors the setup in `placetel/gitops`.

## What's added
`cluster/apps/networking/webhook-receiver/`
- **receiver.yaml** — `Receiver` (type `github`, events `ping`/`push`, targets GitRepository `flux-system`)
- **service.yaml** — Service → `notification-controller` :9292
- **ingress.yaml** — public ingress `flux-webhook.${SECRET_LAB_DOMAIN}` via external Traefik + Cloudflare tunnel, forwards `/hook`
- **secret.sops.yaml** — SOPS-encrypted HMAC token
- **ks.yaml** — Flux Kustomization (wired into `networking/kustomization.yaml`)

Also documents the setup in `CLAUDE.md`.

## Manual steps after merge
1. Reconcile (`task flux:sync`), then read the webhook path:
   `kubectl -n flux-system get receiver github-webhook -o jsonpath='{.status.webhookPath}'`
2. Add the GitHub webhook (repo → Settings → Webhooks):
   - **Payload URL:** `https://flux-webhook.<lab-domain>` + the path from step 1
   - **Content type:** `application/json`
   - **Secret:** (shared out-of-band)
   - **Events:** Just the `push` event