### PR TITLE
fix(metallb): disable frrk8s to keep legacy FRR on chart 0.16.1

### DIFF
--- a/cluster/core/metallb-system/app/helm-release.yaml
+++ b/cluster/core/metallb-system/app/helm-release.yaml
@@ -25,6 +25,10 @@ spec:
   values:
     crds:
       enabled: false
+    # frr-k8s became the default backend in chart 0.16.1; disable it explicitly
+    # to keep the existing legacy FRR (BGP) mode. The two are mutually exclusive.
+    frrk8s:
+      enabled: false
     speaker:
       frr:
         enabled: true


### PR DESCRIPTION
Chart 0.16.1 (PR #1771) defaults `frrk8s.enabled: true`, which is mutually exclusive with the existing `speaker.frr.enabled: true`, causing `Helm upgrade failed ... mutually exclusive`. Explicitly disabling frr-k8s preserves the current legacy FRR (BGP) mode. Verified with `helm template`. Running metallb was unaffected (upgrade failed, old release kept serving).