### PR TITLE
fix(media): Recreate strategy for RWO-backed *arr deployments

### DIFF
--- a/cluster/apps/media/lidarr/app/deployment.yaml
+++ b/cluster/apps/media/lidarr/app/deployment.yaml
@@ -6,6 +6,10 @@ metadata:
   namespace: media
 spec:
   replicas: 1
+  # config PVC is ReadWriteOnce (ceph-rbd); Recreate avoids Multi-Attach
+  # deadlock when a new pod surges before the old one releases the volume
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app.kubernetes.io/name: lidarr

--- a/cluster/apps/media/prowlarr/app/deployment.yaml
+++ b/cluster/apps/media/prowlarr/app/deployment.yaml
@@ -6,6 +6,10 @@ metadata:
   namespace: media
 spec:
   replicas: 1
+  # config PVC is ReadWriteOnce (ceph-rbd); Recreate avoids Multi-Attach
+  # deadlock when a new pod surges before the old one releases the volume
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app.kubernetes.io/name: prowlarr

--- a/cluster/apps/media/radarr/app/deployment.yaml
+++ b/cluster/apps/media/radarr/app/deployment.yaml
@@ -6,6 +6,10 @@ metadata:
   namespace: media
 spec:
   replicas: 1
+  # config PVC is ReadWriteOnce (ceph-rbd); Recreate avoids Multi-Attach
+  # deadlock when a new pod surges before the old one releases the volume
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app.kubernetes.io/name: radarr

--- a/cluster/apps/media/seerr/app/deployment.yaml
+++ b/cluster/apps/media/seerr/app/deployment.yaml
@@ -6,6 +6,10 @@ metadata:
   namespace: media
 spec:
   replicas: 1
+  # config PVC is ReadWriteOnce (ceph-rbd); Recreate avoids Multi-Attach
+  # deadlock when a new pod surges before the old one releases the volume
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app.kubernetes.io/name: seerr

--- a/cluster/apps/media/sonarr/app/deployment.yaml
+++ b/cluster/apps/media/sonarr/app/deployment.yaml
@@ -6,6 +6,10 @@ metadata:
   namespace: media
 spec:
   replicas: 1
+  # config PVC is ReadWriteOnce (ceph-rbd); Recreate avoids Multi-Attach
+  # deadlock when a new pod surges before the old one releases the volume
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app.kubernetes.io/name: sonarr

--- a/cluster/apps/media/tautulli/app/deployment.yaml
+++ b/cluster/apps/media/tautulli/app/deployment.yaml
@@ -6,6 +6,10 @@ metadata:
   namespace: media
 spec:
   replicas: 1
+  # config PVC is ReadWriteOnce (ceph-rbd); Recreate avoids Multi-Attach
+  # deadlock when a new pod surges before the old one releases the volume
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app.kubernetes.io/name: tautulli


### PR DESCRIPTION
prowlarr/radarr/lidarr/sonarr/tautulli/seerr each mount a ReadWriteOnce ceph-rbd config PVC but used the default RollingUpdate strategy, so a new pod surges and deadlocks on Multi-Attach during any image bump (hit live on prowlarr 2.4.0). Switch to `strategy: Recreate` so the old pod releases the volume before the new one starts.