### PR TITLE
fix(evcc): Recreate strategy for RWO-backed deployment

### DIFF
--- a/cluster/apps/default/evcc/app/deployment.yaml
+++ b/cluster/apps/default/evcc/app/deployment.yaml
@@ -6,6 +6,10 @@ metadata:
   namespace: default
 spec:
   replicas: 1
+  # data PVC is ReadWriteOnce (ceph-rbd); Recreate avoids Multi-Attach
+  # deadlock when a new pod surges before the old one releases the volume
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app.kubernetes.io/name: evcc


### PR DESCRIPTION
evcc mounts a ReadWriteOnce ceph-rbd data PVC but used default RollingUpdate, so image bumps deadlock on Multi-Attach (new pod surges before old releases the volume; hit live during this sweep). Switch to Recreate. Same fix as the *arr media deployments (#1790).