### PR TITLE
fix(glitchtip): migrate to chart v8 schema

### DIFF
--- a/cluster/apps/default/evcc/app/deployment.yaml
+++ b/cluster/apps/default/evcc/app/deployment.yaml
@@ -6,6 +6,10 @@ metadata:
   namespace: default
 spec:
   replicas: 1
+  # data PVC is ReadWriteOnce (ceph-rbd); Recreate avoids Multi-Attach
+  # deadlock when a new pod surges before the old one releases the volume
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app.kubernetes.io/name: evcc

--- a/cluster/apps/default/glitchtip/app/helm-release.yaml
+++ b/cluster/apps/default/glitchtip/app/helm-release.yaml
@@ -23,81 +23,82 @@ spec:
     remediation:
       retries: 3
   values:
-    # Default values for glitchtip.
     image:
       repository: glitchtip/glitchtip
-      tag: 6.1.6
+      tag: 6.2.2
       pullPolicy: IfNotPresent
 
-    imagePullSecrets: []
-    nameOverride: ""
-    fullnameOverride: ""
+    # Chart v8 sources SECRET_KEY / DATABASE_URL / REDIS_URL from a Secret
+    # (the old env.normal/env.secret blocks were removed in v8.0.0).
+    glitchtip:
+      domain: https://glitchtip.${SECRET_LAB_DOMAIN}
+      existingSecret: glitchtip-secret
+      existingSecretKey: SECRET_KEY
+      database:
+        existingSecret: glitchtip-secret
+        existingSecretKey: DATABASE_URL
+      valkey:
+        existingSecret: glitchtip-secret
+        existingSecretKey: REDIS_URL
 
-    env:
-      normal:
-        ENABLE_SOCIAL_AUTH: false
-        GLITCHTIP_DOMAIN: https://glitchtip.${SECRET_LAB_DOMAIN}
-        CELERY_WORKER_AUTOSCALE: "1,3"
-        CELERY_WORKER_MAX_TASKS_PER_CHILD: "10000"
-        ENABLE_ORGANIZATION_CREATION: "true"
-      secret:
-        SECRET_KEY: "${GLITCHTIP_SECRET_KEY}"
-        DATABASE_URL: "${GLITCHTIP_DATABASE_URL}"
-        REDIS_URL: "${GLITCHTIP_REDIS_URL}"
-        EMAIL_URL: "${GLITCHTIP_EMAIL_URL}"
-        DEFAULT_FROM_EMAIL: "noreply@${SECRET_LAB_DOMAIN}"
-        DEFAULT_FILE_STORAGE: ${GLITCHTIP_DEFAULT_FILE_STORAGE}
-        AWS_ACCESS_KEY_ID: ${GLITCHTIP_AWS_ACCESS_KEY_ID}
-        AWS_SECRET_ACCESS_KEY: ${GLITCHTIP_AWS_SECRET_ACCESS_KEY}
-        AWS_STORAGE_BUCKET_NAME: ${GLITCHTIP_AWS_STORAGE_BUCKET_NAME}
-        AWS_S3_ENDPOINT_URL: ${GLITCHTIP_AWS_S3_ENDPOINT_URL}
+    # External Postgres (central psql-cluster) and Redis — disable bundled ones.
+    postgresql:
+      enabled: false
+    valkey:
+      enabled: false
+
+    # Remaining env, applied to all components. Secret values via secretKeyRef.
+    extraEnvVars:
+      - name: ENABLE_SOCIAL_AUTH
+        value: "false"
+      - name: ENABLE_ORGANIZATION_CREATION
+        value: "true"
+      - name: CELERY_WORKER_AUTOSCALE
+        value: "1,3"
+      - name: CELERY_WORKER_MAX_TASKS_PER_CHILD
+        value: "10000"
+      - name: DEFAULT_FROM_EMAIL
+        value: "noreply@${SECRET_LAB_DOMAIN}"
+      - name: DEFAULT_FILE_STORAGE
+        value: "${GLITCHTIP_DEFAULT_FILE_STORAGE}"
+      - name: AWS_STORAGE_BUCKET_NAME
+        value: "${GLITCHTIP_AWS_STORAGE_BUCKET_NAME}"
+      - name: AWS_S3_ENDPOINT_URL
+        value: "${GLITCHTIP_AWS_S3_ENDPOINT_URL}"
+      - name: EMAIL_URL
+        valueFrom:
+          secretKeyRef:
+            name: glitchtip-secret
+            key: EMAIL_URL
+      - name: AWS_ACCESS_KEY_ID
+        valueFrom:
+          secretKeyRef:
+            name: glitchtip-secret
+            key: AWS_ACCESS_KEY_ID
+      - name: AWS_SECRET_ACCESS_KEY
+        valueFrom:
+          secretKeyRef:
+            name: glitchtip-secret
+            key: AWS_SECRET_ACCESS_KEY
 
     migrationJob:
       enabled: true
       activeDeadlineSeconds: 900
 
-    valkey:
-      enabled: false
-
+    # web runs the embedded worker + beat (dedicated worker/beat removed in v8).
     web:
+      embedWorker: true
       replicaCount: 1
       autoscaling:
         enabled: false
-        minReplicas: 2
-        maxReplicas: 10
-        targetCPU: 80
-        # targetMemory: 80
       budget:
         minAvailable: 1
-      nodeSelector: {}
-      tolerations: []
-      podAnnotations: {}
-      affinity:
-        podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-            - weight: 100
-              podAffinityTerm:
-                labelSelector:
-                  matchExpressions:
-                    - key: app.kubernetes.io/component
-                      operator: In
-                      values:
-                        - web # Change this as needed
-                topologyKey: kubernetes.io/hostname
-      livenessProbe:
-        failureThreshold: 5
-        initialDelaySeconds: 5
-        timeoutSeconds: 3
-      readinessProbe:
-        failureThreshold: 10
-        initialDelaySeconds: 5
-        timeoutSeconds: 2
       service:
         type: ClusterIP
         port: 80
-
       ingress:
         enabled: true
+        className: traefik
         annotations:
           hajimari.io/enable: "true"
           hajimari.io/icon: "alert-circle"
@@ -106,7 +107,6 @@ spec:
           external-dns.alpha.kubernetes.io/cloudflare-proxied: "true"
           traefik.ingress.kubernetes.io/router.middlewares: "networking-cloudflarewarp@kubernetescrd"
           external-dns/external: "true"
-        ingressClassName: traefik
         hosts:
           - host: glitchtip.${SECRET_LAB_DOMAIN}
             paths:
@@ -117,71 +117,9 @@ spec:
               - "glitchtip.${SECRET_LAB_DOMAIN}"
             secretName: "${SECRET_LAB_DOMAIN/./-}-tls"
 
+    # Dedicated worker not needed — embedded in web via embedWorker.
     worker:
-      enabled: true
-      replicaCount: 1
-      autoscaling:
-        enabled: false
-        minReplicas: 1
-        maxReplicas: 10
-        targetCPU: 100
-        # targetMemory: 80
-      livenessProbe:
-        initialDelaySeconds: 10
-        periodSeconds: 60
-        timeoutSeconds: 30
-        exec:
-          command:
-            - "bash"
-            - "-c"
-            - "celery -A glitchtip inspect ping -d celery@$HOSTNAME | grep -q OK"
-      nodeSelector: {}
-      tolerations: []
-      podAnnotations: {}
-      affinity: {}
-
-    beat:
-      enabled: true
-      nodeSelector: {}
-      tolerations: []
-      podAnnotations: {}
-      affinity: {}
-
-    flower:
       enabled: false
-      nodeSelector: {}
-      tolerations: []
-      podAnnotations: {}
-      affinity: {}
-      service:
-        type: ClusterIP
-        port: 80
-      ingress:
-        enabled: false
-        annotations:
-          {}
-          # kubernetes.io/ingress.class: nginx
-          # kubernetes.io/tls-acme: "true"
-        hosts:
-          - host: chart-example.local
-            paths:
-              - path: /
-                pathType: ImplementationSpecific
-        tls: []
-        #  - secretName: chart-example-tls
-        #    hosts:
-        #      - chart-example.local
 
     serviceAccount:
-      # Specifies whether a service account should be created
       create: false
-      # The name of the service account to use.
-      # If not set and create is true, a name is generated using the fullname template
-      name:
-
-    # Default to disabled, use a managed database service. But can be enabled here.
-    # For configuration options, see https://artifacthub.io/packages/helm/bitnami/postgresql
-    postgresql:
-      enabled: false
-      # auth:
-      #   postgresPassword: # Must be set

--- a/cluster/apps/default/glitchtip/app/kustomization.yaml
+++ b/cluster/apps/default/glitchtip/app/kustomization.yaml
@@ -2,4 +2,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - secret.sops.yaml
   - helm-release.yaml

--- a/cluster/apps/default/glitchtip/app/secret.sops.yaml
+++ b/cluster/apps/default/glitchtip/app/secret.sops.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: glitchtip-secret
+    namespace: default
+type: Opaque
+stringData:
+    SECRET_KEY: ENC[AES256_GCM,data:D06G+hc9leuKVraoSav516yoJD7WZ4+9lm+3ifyNb7sc33f768HV+0XOKBE=,iv:Jdge7/FGc8ccVDGBvAIt+6kkAJUcoMwl7RY9imDXkAg=,tag:Xhkqyh6hj/j42cPITavAng==,type:str]
+    DATABASE_URL: ENC[AES256_GCM,data:jYhgH1gFs6ZKLFyYx52S9GmNUOVlgQ46R8RqDjp7InqCDXC6FXo791Qw3l4lb8RQCTSq7AURpRR3OAYRcoA/tTWGUZbwCO2ld0SyaWpegUTII90TsGFrrMPjwKM=,iv:t60VIqV/Z4Jcgew6cdmyojai4iHCEfsMkVKCEQcfsK4=,tag:luFeFRlMeqI4/f40WhPOlg==,type:str]
+    REDIS_URL: ENC[AES256_GCM,data:LDFGZRnrHjKUuCTQXRaMYWNelivVuEwGEscA3XPAJF+btA5RV8AVMYVrdXj0izupfPI4sLMEPMa759NkMS9t,iv:IERaLbXwnsMS8/gGnoU86AHZgRQDcNdxJUsLHRGiwQU=,tag:MnobUzY/MrANpvj5Rkf0GA==,type:str]
+    EMAIL_URL: ENC[AES256_GCM,data:TTxRqRt5iqqL316gCfEKFdov2oc1XYT4jL/xqVvKJoTZcrtzWWrN83i5FPWe+F7+3A==,iv:ZElH6UXk+XVD49FsAIXaJMEM3npYkPTV4P5NvTd4x7w=,tag:8+So3bQb478XfNKVxLly0Q==,type:str]
+    AWS_ACCESS_KEY_ID: ENC[AES256_GCM,data:WEkaCzVz5QigP/qv5O3dhSM+G1sQNLUPeQ==,iv:Wcoaz+6OrYA6g9RI/4NsE4xAbKrGTIYrdtOwKT3ljW0=,tag:i/KmUfV6DFiYyG106e3fdA==,type:str]
+    AWS_SECRET_ACCESS_KEY: ENC[AES256_GCM,data:9l+VfxhgW4/OusaBPQ6vcjQGwwa8j3lCX/B8lG4+sg==,iv:jeULZp6pTmE3sd/WhRq/x8QlBcWiTub/+94AvfRjzCE=,tag:NC+/UfYd4HZaQ1PeaF52jg==,type:str]
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBEWVpxSjB5QjFQRnBHc3dm
+            SGFEZTJBSlA5SkdOcVdMdDJweTFKaVJhNEcwCmF6eDJtS29JT01RcjV2anlrVnFM
+            c3pUb083T3Y5ampNcUVFdlAvblpNcjAKLS0tIDRVSkhTbyt4Zk9zZUczTk9ieFFB
+            R0NhWGloVm9ZUGdKTk1hY1ZtUlBwenMK2HXqku8gATJvDqKq/OAZ7ntHUNP8Rc4n
+            lrFwYVz6N43y6k+9vJdx1xuKgxaz7FOG9y2vKILHVTXE86lf1Dci9Q==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1f897y4l6lrasc0rcgrkz3q4054rk7ewa6gh7g4zruk0vzjp22a9sl6fr55
+    encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-07-19T21:35:55Z"
+    mac: ENC[AES256_GCM,data:O0pInnzVuQfz9DPi/2GnSIxl5VS2XdXfAdkgKOtCJ4rbM7QvSrBvMPWDRAM3uYBfxBXuxKq4aOx3ngV49C6pfq3or++npZ4JcXrWms03tFFPXriaUJOVG+/mea+Y7s2Iqv9dtFyX9/ETHWIl39y6wJDN953qa26Xsul2yEgjThc=,iv:GvUC4hDJalxrLZb5HkwAO5F8M3hiZgZAVVqd0jusfTU=,tag:QYZmSHQ/iQuKD+gC6wmpgQ==,type:str]
+    version: 3.13.2


### PR DESCRIPTION
glitchtip HR declared chart 8.2.0 but still used the v7 env.normal/env.secret values that v8.0.0 removed (hard-fails), so it had been stuck ~2 months running app v5.1.1. Rewrite to the v8 schema:
- SECRET_KEY/DATABASE_URL/REDIS_URL via new SOPS secret `glitchtip-secret` (existingSecret refs)
- glitchtip.domain, extraEnvVars for the rest (EMAIL/S3 creds via secretKeyRef)
- external postgres+redis (postgresql.enabled=false, valkey.enabled=false)
- embedded worker/beat (web.embedWorker), dedicated worker/beat removed in v8
Triggers app upgrade v5.1.1 -> 6.2.2 with DB migrations (DB backed up pre-merge). Validated with helm template.