### PR TITLE
feat(traefik): upgrade to v41.1.0

### DIFF
--- a/cluster/apps/networking/traefik/app/helm-release.yaml
+++ b/cluster/apps/networking/traefik/app/helm-release.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       # renovate: registryUrl=https://helm.traefik.io/traefik
       chart: traefik
-      version: 39.0.9
+      version: 41.1.0
       sourceRef:
         kind: HelmRepository
         name: traefik-charts
@@ -49,17 +49,15 @@ spec:
         - name: plugins
     service:
       enabled: true
-      type: LoadBalancer
       spec:
+        type: LoadBalancer
         loadBalancerIP: "${METALLB_TRAEFIK_ADDR}"
         externalTrafficPolicy: Local
-    logs:
-      general:
-        format: common
-        level: ERROR
-      access:
-        enabled: true
-        format: common
+    log:
+      format: common
+      level: ERROR
+    accessLog:
+      format: common
     ingressClass:
       enabled: true
       isDefaultClass: false
@@ -178,7 +176,7 @@ spec:
     spec:
       # renovate: registryUrl=https://helm.traefik.io/traefik
       chart: traefik
-      version: 39.0.9
+      version: 41.1.0
       sourceRef:
         kind: HelmRepository
         name: traefik-charts
@@ -212,17 +210,15 @@ spec:
       replicas: 2
     service:
       enabled: true
-      type: LoadBalancer
       spec:
+        type: LoadBalancer
         loadBalancerIP: "${METALLB_TRAEFIK_INTERNAL_ADDR}"
         externalTrafficPolicy: Local
-    logs:
-      general:
-        format: common
-        level: ERROR
-      access:
-        enabled: true
-        format: common
+    log:
+      format: common
+      level: ERROR
+    accessLog:
+      format: common
     ingressClass:
       name: traefik-internal
       enabled: true

--- a/cluster/crds/traefik/crds.yaml
+++ b/cluster/crds/traefik/crds.yaml
@@ -9,7 +9,7 @@ spec:
   url: https://github.com/traefik/traefik-helm-chart.git
   ref:
     # renovate: registryUrl=https://helm.traefik.io/traefik chart=traefik
-    tag: v39.0.9
+    tag: v41.1.0
   ignore: |
     # exclude all
     /*


### PR DESCRIPTION
Supersedes #1787 + #1781. v40/v41 removed top-level service.type and renamed logs.general->log / logs.access->accessLog. Rewrote both HRs (external + internal) accordingly, moved type into service.spec.type (prevents the silent LoadBalancer-drop), bumped chart 39.0.9->41.1.0 and traefik-crd-source v39.0.9->v41.1.0. Validated both with helm template against 41.1.0: Service renders LoadBalancer with the MetalLB IP; log/accessLog accepted.