### PR TITLE
feat(cert-manager): upgrade to v1.21.1

### DIFF
--- a/cluster/core/cert-manager/app/helm-release.yaml
+++ b/cluster/core/cert-manager/app/helm-release.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       # renovate: registryUrl=https://charts.jetstack.io/
       chart: cert-manager
-      version: v1.19.6
+      version: v1.21.1
       sourceRef:
         kind: HelmRepository
         name: jetstack-charts

--- a/cluster/crds/cert-manager/kustomization.yaml
+++ b/cluster/crds/cert-manager/kustomization.yaml
@@ -2,4 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   # renovate: registryUrl=https://charts.jetstack.io chart=cert-manager
-  - https://github.com/jetstack/cert-manager/releases/download/v1.19.6/cert-manager.crds.yaml
+  - https://github.com/jetstack/cert-manager/releases/download/v1.21.1/cert-manager.crds.yaml


### PR DESCRIPTION
Bumps cert-manager chart v1.19.6 -> v1.21.1 and the separately-managed CRDs to match (CRDs reconcile before core, so they land first). No breaking values for this deployment (Cloudflare DNS01 only; no Gateway API, no prometheus servicemonitor values, no serviceAccountRef). Validated with helm template. Supersedes #1766.